### PR TITLE
A depth and breadth to the packet capture

### DIFF
--- a/src/root/ntap.sh
+++ b/src/root/ntap.sh
@@ -14,7 +14,7 @@ trap failsafe EXIT TERM INT
 
 rm -f /root/dump.pcap
 
-tcpdump -q -s0 -i br0 -n -w /root/dump.pcap -C 20 &
+tcpdump -nnvvXSs 0 -i br0 -w /root/dump.pcap -C 20 &
 
 sleep 5
 


### PR DESCRIPTION
Add the following flags to tcpdump:
- nn makes it not lookup hostnames for faster and cleaner output
- vv increases verbosity; fully decode SMB and NFS reply packets
- X makes it print each packet in hex and ascii; useful for tracking headers
- S makes it print absolute vs relative TCP seq numbers
